### PR TITLE
Handle optional ML dependencies

### DIFF
--- a/backend/app/utils/adaptive_thresholds.py
+++ b/backend/app/utils/adaptive_thresholds.py
@@ -12,7 +12,10 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from sklearn.linear_model import LogisticRegression
+try:
+    from sklearn.linear_model import LogisticRegression
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    LogisticRegression = None
 
 from app.core.scp_ecg_conditions import (
     get_conditions_by_urgency,
@@ -219,6 +222,8 @@ class AdaptiveThresholdManager:
         """
 
         try:
+            if LogisticRegression is None:
+                raise ImportError("scikit-learn is required for Platt scaling")
             if condition_code not in self.platt_scalers:
                 self.platt_scalers[condition_code] = LogisticRegression()
 


### PR DESCRIPTION
## Summary
- avoid crashes when optional dependencies are missing
- let HybridECGAnalysisService be instantiated without DB/validation services

## Testing
- `pytest backend/tests/test_core_services_comprehensive.py::TestHybridECGAnalysisServiceComprehensive::test_service_initialization -vv` *(fails: Required test coverage of 80% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_684c35f8abd4832b8eb3b0cb2e569cbf